### PR TITLE
Fix inconsitencies with openinverter_can_tool can mapping

### DIFF
--- a/esp32-web-interface.ino
+++ b/esp32-web-interface.ino
@@ -738,7 +738,6 @@ void setup(void){
   });
 
   server.begin();
-  server.client().setNoDelay(1);
 
   MDNS.addService("http", "tcp", 80);
 }


### PR DESCRIPTION
Ensure that can maps can be configured with the full capabilities of the current libopeninv can mapping functionality.

- Fix the display of mappings with negative gain values
- Fix the adding of mappings with negative offset values
- Remove an erroneous web server warning found during testing