### PR TITLE
Add direct SDO CAN map clear action

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -506,7 +506,7 @@
 						<button onclick="modal.showModal('can-mapping');">
 							<!-- /icon-plus-circle.png -->
 							<img class="buttonimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAYVJREFUSInFlb9OAkEQxn9acfGaI3bQc/gO/n0AtLM1Rn0FDY9kpZSKiUil0qqAiY1Xi4ZeLHYmt0eO2yWB+CWbTeZmvvluZncWlowVx/cycAA0gBioij0B+kALuAK+5k0cAE3gB5g41rf4Br7kVaBnEdwAJ0ANWJMVA6fAreXXAyo+5IkEDIAtD0HbwFBikqIkgaX8Hog8yBUR0JHYJ6CU59QkVT4PuaIMvAvHRd5HbWhRWbqyZmGHtPEZkcekDS2CNrQIbfE5AlgVY0P2S0ewD5SjYRsHkrXmCPb5g1h8+rZxLMZwyrmL+6JN9yQU+xjSEi0SyvlrG5dWIs32Kvumr8wC6DF/sRO0ZD9cQALlaNnGMuZyTDCzZRZcF21POEbkTAMdFR/AurferEgdFed5DiXgWRw6eQoc5A84hh2YUavjeoiZLS7skir/xONNqIgKPZJt4AyoYy5RCGyI7c7ye/QhV5QwI1cbX7RGmJrnlsX16EfAPmZw1ck++m+Yo3gtSf4Hf6VKhAI+0rkQAAAAAElFTkSuQmCC">Add new mapping</button>
-						<button onclick="ui.sendCmd('can clear');">
+						<button onclick="ui.showClearCanMappingConfirmationModal();">
 							<!-- /icon-trash-2.png -->
 							<img class="buttonimg" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAKNJREFUSIntlmEKhCAQhT+Wpb1T0fXatmu5V9GOUT8yCHdCJ6kt6MGgw9N5Myoq/BkvoAMcMATmgA9Q5Ah0QuDQ2hyBOfNS4CrP2RyBOcutPI9F3/BbfhgolTeSwGGIlq2Zt3sFpxEwLDZO8FWQ1nLt1MTmnWeJboH98Ewc9434Klz/quh9Wyni1L51KYNb4s/kmjUpAgXTY24VgS3wJvMDsAkjQRJaZqmk/aEAAAAASUVORK5CYII=">Remove all mappings</button>
 						<button onclick="ui.showParamsSavedModal();">

--- a/data/inverter.js
+++ b/data/inverter.js
@@ -134,7 +134,33 @@ var inverter = {
 
     xmlhttp.onload = function()
     {
+      if (xmlhttp.status != 200) {
+        var messageBox = document.getElementById("message");
+        if (messageBox) {
+          messageBox.innerHTML = this.responseText;
+        }
+        return;
+      }
+
       if (replyFunc) replyFunc(JSON.parse(this.responseText));
+    }
+
+    xmlhttp.onreadystatechange = function() {
+      if (xmlhttp.readyState === XMLHttpRequest.DONE) {
+        console.log(req + ": " + xmlhttp.status);
+        if (xmlhttp.status != 200) {
+          paramsCache.failedFetchCount += 1;
+          if ( paramsCache.failedFetchCount >= 2 && typeof ui !== 'undefined'){
+            ui.showCommunicationErrorBar();
+          }
+        }
+        else {
+          paramsCache.failedFetchCount = 0;
+        }
+        if ( paramsCache.failedFetchCount < 2 && typeof ui !== 'undefined') {
+          ui.hideCommunicationErrorBar();
+        }
+      }
     }
 
     xmlhttp.open("GET", req, true);
@@ -150,6 +176,11 @@ var inverter = {
    */
   canDelete: function(replyFunc, index, subindex) {
     inverter.canMapping(replyFunc, "?remove={\"index\":" + index + ",\"subindex\":" + subindex + "}");
+  },
+
+  /** @brief Clear all CAN mappings */
+  clearCanMapping: function(replyFunc) {
+    inverter.canMapping(replyFunc, "?clear=1");
   },
 
   /** @brief Add a CAN mapping

--- a/data/ui.js
+++ b/data/ui.js
@@ -1221,6 +1221,29 @@ var ui = {
 		modal.hideModal('can-mapping');
 	},
 
+	/** @brief Ask for confirmation before clearing all CAN mappings */
+	showClearCanMappingConfirmationModal: function()
+	{
+		modal.emptyModal('small');
+		var msg = "<p>Are you sure you want to clear all CAN mappings?</p>";
+		msg += "<div style=\"display:flex;\">";
+		msg += "<button onclick=\"ui.clearCanMapping();\"><img class=\"buttonimg\" src=\"/icon-trash.png\">Clear mappings</button>";
+		msg += "<button onclick=\"modal.hideModal('small');\"><img class=\"buttonimg\" src=\"/icon-x-square.png\">Cancel</button>";
+		msg += "</div>";
+		modal.appendToModal('small', msg);
+		modal.showModal('small');
+	},
+
+	/** @brief Clear all CAN mappings via direct SDO and reload the table */
+	clearCanMapping: function()
+	{
+		modal.hideModal('small');
+		inverter.clearCanMapping(function(values) {
+			ui.populateExistingCanMappingTable(values);
+			ui.showParamSuccessBar('CAN mappings cleared');
+		});
+	},
+
 	/** @brief Populate the table of existing CAN mappings */
 	populateExistingCanMappingTable: function(values) {
 		var existigCanMappingTable = document.getElementById("existingCanMappingTable");

--- a/esp32-web-interface.ino
+++ b/esp32-web-interface.ino
@@ -563,6 +563,9 @@ static void handleCanMap() {
   if (server.hasArg("add")) {
     res = OICan::AddCanMapping(server.arg("add"));
   }
+  else if (server.hasArg("clear")) {
+    res = OICan::ClearCanMapping();
+  }
   else if (server.hasArg("remove")) {
     res = OICan::RemoveCanMapping(server.arg("remove"));
   }

--- a/src/oi_can.cpp
+++ b/src/oi_can.cpp
@@ -57,6 +57,7 @@
 #define SDO_CMD_LOAD          1
 #define SDO_CMD_RESET         2
 #define SDO_CMD_DEFAULTS      3
+#define SDO_CMD_CLEAR_CAN     4
 #define SDO_CMD_START         4
 #define SDO_CMD_STOP          5
 #define MAX_ERROR_LOG_ENTRIES 100
@@ -555,6 +556,31 @@ SetResult RemoveCanMapping(String json){
       return UnknownIndex;
     }
   }
+  DBG_OUTPUT_PORT.println("Comm Error");
+  return CommError;
+}
+
+SetResult ClearCanMapping() {
+  if (state != IDLE) return CommError;
+
+  twai_message_t rxframe;
+
+  setValueSdo(SDO_INDEX_COMMANDS, SDO_CMD_CLEAR_CAN, 0U);
+
+  if (twai_receive(&rxframe, pdMS_TO_TICKS(200)) == ESP_OK) {
+    if (rxframe.data[0] == SDO_WRITE_REPLY &&
+        rxframe.data[1] == 0x02 &&
+        rxframe.data[2] == 0x50 &&
+        rxframe.data[3] == SDO_CMD_CLEAR_CAN) {
+      DBG_OUTPUT_PORT.println("CAN mappings cleared");
+      return Ok;
+    }
+    else if (rxframe.data[0] == SDO_ABORT) {
+      DBG_OUTPUT_PORT.println("Clear CAN mappings aborted");
+      return UnknownIndex;
+    }
+  }
+
   DBG_OUTPUT_PORT.println("Comm Error");
   return CommError;
 }

--- a/src/oi_can.h
+++ b/src/oi_can.h
@@ -30,6 +30,7 @@ void Loop();
 bool SendJson(WiFiClient c);
 void SendCanMapping(WiFiClient c);
 SetResult AddCanMapping(String json);
+SetResult ClearCanMapping();
 SetResult RemoveCanMapping(String json);
 SetResult SetValue(String name, double value);
 double GetValue(String name);


### PR DESCRIPTION
## Summary
Add a dedicated "Remove all mappings" action for libopeninverter CAN mapping that uses a direct SDO write instead of the terminal command transport. Button was anyways dead and copy and paste error from uart backend.

## Changes
- replace the CAN mapping clear button handler with a confirmation flow in the web UI
- add a frontend CAN-map clear request path that reloads the table after success
- add `/canmap?clear=1` support in the firmware CAN map handler
- send SDO write `0x5002` / subindex `4` / data `0` and require the matching SDO write reply before reporting success